### PR TITLE
refactor(object_store): add typespec, simplify get/3 patterns, elimin…

### DIFF
--- a/lib/sfera_doc/pdf/object_store.ex
+++ b/lib/sfera_doc/pdf/object_store.ex
@@ -30,6 +30,7 @@ defmodule SferaDoc.Pdf.ObjectStore do
   Returns a child spec for the configured adapter, or `nil` if no adapter is
   configured or the adapter does not require a supervised process.
   """
+  @spec worker_spec() :: Supervisor.child_spec() | nil
   def worker_spec do
     case adapter() do
       nil -> nil
@@ -48,7 +49,7 @@ defmodule SferaDoc.Pdf.ObjectStore do
 
       mod ->
         case mod.get(name, version, hash) do
-          {:ok, binary} -> {:ok, binary}
+          {:ok, _} = ok -> ok
           :miss -> :miss
           {:error, _} -> :miss
         end

--- a/lib/sfera_doc/pdf/object_store/azure.ex
+++ b/lib/sfera_doc/pdf/object_store/azure.ex
@@ -40,8 +40,8 @@ defmodule SferaDoc.Pdf.ObjectStore.Azure do
   @impl true
   def get(name, version, hash) do
     ensure_deps!()
-    blob = blob_name(name, version, hash)
     opts = Application.get_env(:sfera_doc, :pdf_object_store, [])
+    blob = blob_name(name, version, hash, opts)
     azurex_opts = azurex_opts(opts)
 
     case apply(Azurex.Blob, :get_blob, [blob, azurex_opts]) do
@@ -63,8 +63,8 @@ defmodule SferaDoc.Pdf.ObjectStore.Azure do
   @impl true
   def put(name, version, hash, binary) do
     ensure_deps!()
-    blob = blob_name(name, version, hash)
     opts = Application.get_env(:sfera_doc, :pdf_object_store, [])
+    blob = blob_name(name, version, hash, opts)
     azurex_opts = azurex_opts(opts)
 
     case apply(Azurex.Blob, :put_blob, [blob, binary, "application/pdf", azurex_opts]) do
@@ -84,8 +84,7 @@ defmodule SferaDoc.Pdf.ObjectStore.Azure do
   # Private
   # ---------------------------------------------------------------------------
 
-  defp blob_name(name, version, hash) do
-    opts = Application.get_env(:sfera_doc, :pdf_object_store, [])
+  defp blob_name(name, version, hash, opts) do
     prefix = Keyword.get(opts, :prefix, "")
     "#{prefix}#{name}/#{version}/#{hash}.pdf"
   end

--- a/lib/sfera_doc/pdf/object_store/s3.ex
+++ b/lib/sfera_doc/pdf/object_store/s3.ex
@@ -30,8 +30,8 @@ defmodule SferaDoc.Pdf.ObjectStore.S3 do
   @impl true
   def get(name, version, hash) do
     ensure_deps!()
-    key = object_key(name, version, hash)
     opts = Application.get_env(:sfera_doc, :pdf_object_store, [])
+    key = object_key(name, version, hash, opts)
     bucket = Keyword.fetch!(opts, :bucket)
     ex_aws_opts = Keyword.get(opts, :ex_aws, [])
 
@@ -56,8 +56,8 @@ defmodule SferaDoc.Pdf.ObjectStore.S3 do
   @impl true
   def put(name, version, hash, binary) do
     ensure_deps!()
-    key = object_key(name, version, hash)
     opts = Application.get_env(:sfera_doc, :pdf_object_store, [])
+    key = object_key(name, version, hash, opts)
     bucket = Keyword.fetch!(opts, :bucket)
     ex_aws_opts = Keyword.get(opts, :ex_aws, [])
 
@@ -80,8 +80,7 @@ defmodule SferaDoc.Pdf.ObjectStore.S3 do
   # Private
   # ---------------------------------------------------------------------------
 
-  defp object_key(name, version, hash) do
-    opts = Application.get_env(:sfera_doc, :pdf_object_store, [])
+  defp object_key(name, version, hash, opts) do
     prefix = Keyword.get(opts, :prefix, "")
     "#{prefix}#{name}/#{version}/#{hash}.pdf"
   end


### PR DESCRIPTION
…ate double config reads

- Add @spec for worker_spec/0, which was the only public function missing a typespec
- Simplify identity pattern match in get/3: {:ok, binary} -> {:ok, binary} becomes {:ok, _} = ok -> ok
- Eliminate redundant Application.get_env calls in S3 and Azure adapters: object_key/blob_name helpers now receive opts from their callers instead of re-reading config independently

Closes #23